### PR TITLE
Use gp3 EBS volumes for ec2_worker

### DIFF
--- a/modules/ec2_worker/main.tf
+++ b/modules/ec2_worker/main.tf
@@ -14,7 +14,7 @@ resource "aws_instance" "ec2_worker" {
 
   root_block_device {
     volume_size = var.volume_size
-    volume_type = "gp2"
+    volume_type = "gp3"
     tags = {
       Name = "${var.project_slug}-${count.index}"
     }


### PR DESCRIPTION
This will force re-provisioning of any `ec2_worker` instances.