### PR TITLE
Remove references to Heroku "hobby" service tiers

### DIFF
--- a/modules/heroku/variables.tf
+++ b/modules/heroku/variables.tf
@@ -42,7 +42,7 @@ variable "additional_buildpacks" {
 variable "web_dyno_size" {
   type        = string
   nullable    = false
-  default     = "hobby"
+  default     = "basic"
   description = "The web server dyno size."
 }
 
@@ -56,7 +56,7 @@ variable "web_dyno_quantity" {
 variable "worker_dyno_size" {
   type        = string
   nullable    = false
-  default     = "hobby"
+  default     = "basic"
   description = "The worker dyno size."
 }
 
@@ -70,7 +70,7 @@ variable "worker_dyno_quantity" {
 variable "postgresql_plan" {
   type        = string
   nullable    = true
-  default     = "hobby-dev"
+  default     = "mini"
   description = "The Postgres add-on plan type, or null to disable."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -82,7 +82,7 @@ variable "additional_sensitive_django_vars" {
 variable "heroku_web_dyno_size" {
   type        = string
   nullable    = false
-  default     = "hobby"
+  default     = "basic"
   description = "The Heroku web server dyno size."
 }
 
@@ -96,7 +96,7 @@ variable "heroku_web_dyno_quantity" {
 variable "heroku_worker_dyno_size" {
   type        = string
   nullable    = false
-  default     = "hobby"
+  default     = "basic"
   description = "The Heroku worker dyno size."
 }
 
@@ -110,7 +110,7 @@ variable "heroku_worker_dyno_quantity" {
 variable "heroku_postgresql_plan" {
   type        = string
   nullable    = true
-  default     = "hobby-dev"
+  default     = "mini"
   description = "The Heroku Postgres add-on plan type, or null to disable."
 }
 


### PR DESCRIPTION
These tiers have been removed from the platform. Instead we default to "basic" dyno tiers, and "mini" (the smallest) postgres tier.