### PR TITLE
Use "basic" as the default Heroku Postgres plan

### DIFF
--- a/modules/heroku/variables.tf
+++ b/modules/heroku/variables.tf
@@ -70,7 +70,7 @@ variable "worker_dyno_quantity" {
 variable "postgresql_plan" {
   type        = string
   nullable    = true
-  default     = "mini"
+  default     = "basic"
   description = "The Postgres add-on plan type, or null to disable."
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -110,7 +110,7 @@ variable "heroku_worker_dyno_quantity" {
 variable "heroku_postgresql_plan" {
   type        = string
   nullable    = true
-  default     = "mini"
+  default     = "basic"
   description = "The Heroku Postgres add-on plan type, or null to disable."
 }
 


### PR DESCRIPTION
See: https://elements.heroku.com/addons/heroku-postgresql

For $9 vs $5, the "basic" plan provides 10m rows instead of 10k rows.