### PR TITLE
Use `essential-1` as the default postgres plan

### DIFF
--- a/modules/heroku/variables.tf
+++ b/modules/heroku/variables.tf
@@ -70,7 +70,7 @@ variable "worker_dyno_quantity" {
 variable "postgresql_plan" {
   type        = string
   nullable    = true
-  default     = "essential-1"
+  default     = "essential-0"
   description = "The Postgres add-on plan type, or null to disable."
 }
 

--- a/modules/heroku/variables.tf
+++ b/modules/heroku/variables.tf
@@ -70,7 +70,7 @@ variable "worker_dyno_quantity" {
 variable "postgresql_plan" {
   type        = string
   nullable    = true
-  default     = "basic"
+  default     = "essential-1"
   description = "The Postgres add-on plan type, or null to disable."
 }
 


### PR DESCRIPTION
Fixes #79 

`essential-1` is equivalent to the old `basic` tier, so I went with that. It's worth noting that there is an even cheaper `essential-0` tier that is equivalent to the old `mini` tier, although it looks like there was an [explicit decision](https://github.com/girder/terraform-heroku-girder4/commit/8501f967a11210e0d340cc66f0173335f1423e20) made to use `basic` instead so I went with `essential-1`.

See https://devcenter.heroku.com/articles/heroku-postgres-plans#essential-tier