### PR TITLE
RFC: Switch from CloudAMQP to Redis addon in Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This facilitates deployment of Django applications created from the
 [Girder4 cookiecutter](https://github.com/girder/cookiecutter-girder-4).
 It creates a Heroku app with addons for
 [PostgreSQL](https://elements.heroku.com/addons/heroku-postgresql),
-[CloudAMQP](https://elements.heroku.com/addons/cloudamqp),
+[Redis](https://elements.heroku.com/addons/heroku-redis),
 and [Papertrail](https://elements.heroku.com/addons/papertrail).
 It also creates
 [AWS S3](https://aws.amazon.com/s3/) storage,

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,7 @@ module "heroku" {
   worker_dyno_size      = var.heroku_worker_dyno_size
   worker_dyno_quantity  = var.heroku_worker_dyno_quantity
   postgresql_plan       = var.heroku_postgresql_plan
-  cloudamqp_plan        = var.heroku_cloudamqp_plan
+  redis_plan            = var.heroku_redis_plan
   papertrail_plan       = var.heroku_papertrail_plan
 }
 

--- a/modules/heroku/main.tf
+++ b/modules/heroku/main.tf
@@ -14,10 +14,9 @@ resource "heroku_app" "heroku" {
   acm        = true # SSL certs for custom domain
 
   # Auto-created (by addons) config vars:
-  # * CLOUDAMQP_APIKEY
-  # * CLOUDAMQP_URL
   # * DATABASE_URL
   # * PAPERTRAIL_API_TOKEN
+  # * REDIS_URL
   config_vars           = var.config_vars
   sensitive_config_vars = var.sensitive_config_vars
 }
@@ -42,10 +41,10 @@ resource "heroku_addon" "heroku_postgresql" {
   plan   = "heroku-postgresql:${var.postgresql_plan}"
 }
 
-resource "heroku_addon" "heroku_cloudamqp" {
-  count  = var.cloudamqp_plan == null ? 0 : 1
+resource "heroku_addon" "heroku_redis" {
+  count  = var.redis_plan == null ? 0 : 1
   app_id = heroku_app.heroku.id
-  plan   = "cloudamqp:${var.cloudamqp_plan}"
+  plan   = "heroku-redis:${var.redis_plan}"
 }
 
 resource "heroku_addon" "heroku_papertrail" {

--- a/modules/heroku/variables.tf
+++ b/modules/heroku/variables.tf
@@ -74,11 +74,11 @@ variable "postgresql_plan" {
   description = "The Postgres add-on plan type, or null to disable."
 }
 
-variable "cloudamqp_plan" {
+variable "redis_plan" {
   type        = string
   nullable    = true
-  default     = "lemur"
-  description = "The CloudAMQP add-on plan type, or null to disable."
+  default     = "mini"
+  description = "The Heroku Data for Redis add-on plan type, or null to disable."
 }
 
 variable "papertrail_plan" {

--- a/modules/heroku/versions.tf
+++ b/modules/heroku/versions.tf
@@ -14,10 +14,6 @@ moved {
   to   = heroku_addon.heroku_postgresql[0]
 }
 moved {
-  from = heroku_addon.heroku_cloudamqp
-  to   = heroku_addon.heroku_cloudamqp[0]
-}
-moved {
   from = heroku_addon.heroku_papertrail
   to   = heroku_addon.heroku_papertrail[0]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -114,11 +114,11 @@ variable "heroku_postgresql_plan" {
   description = "The Heroku Postgres add-on plan type, or null to disable."
 }
 
-variable "heroku_cloudamqp_plan" {
+variable "heroku_redis_plan" {
   type        = string
   nullable    = true
-  default     = "lemur"
-  description = "The Heroku CloudAMQP add-on plan type, or null to disable."
+  default     = "mini"
+  description = "The Heroku Data for Redis add-on plan type, or null to disable."
 }
 
 variable "heroku_papertrail_plan" {


### PR DESCRIPTION
These are the terraform changes to support https://github.com/kitware-resonant/django-composed-configuration/pull/213 and https://github.com/kitware-resonant/cookiecutter-resonant/pull/213

