### PR TITLE
Limit ASGI_THREADS value in Heroku

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -39,6 +39,9 @@ module "heroku" {
 
   config_vars = merge(
     {
+      # Must limit threads so as not to exhaust postgres connection pool
+      # https://mattbasta.medium.com/django-channels-asgi-and-heroku-e1bc9559330b
+      ASGI_THREADS                       = 5
       AWS_ACCESS_KEY_ID                  = aws_iam_access_key.heroku_user.id
       AWS_DEFAULT_REGION                 = data.aws_region.current.name
       DJANGO_CONFIGURATION               = "HerokuProductionConfiguration"


### PR DESCRIPTION
The default value is far too high and quickly exhausts postgres's default connection pool limit of 20 in Heroku.

This is related to the same cluster of Resonant PRs as #81 